### PR TITLE
Esperanto + Adblock rewrite

### DIFF
--- a/lib/api/context/event.ts
+++ b/lib/api/context/event.ts
@@ -11,6 +11,7 @@ const { logger } = registerContext({
 
 export type EventType =
     | "platformLoaded"
+    | "esperantoLoaded"
     | "reduxLoaded"
     | "play"
     | "pause"
@@ -23,6 +24,7 @@ export type EventType =
 
 export interface EventArgs {
     platformLoaded: [];
+    esperantoLoaded: [];
     reduxLoaded: [store: Store];
     play: [state: PlayerState];
     pause: [state: PlayerState];

--- a/lib/api/context/event.ts
+++ b/lib/api/context/event.ts
@@ -11,7 +11,6 @@ const { logger } = registerContext({
 
 export type EventType =
     | "platformLoaded"
-    | "esperantoLoaded"
     | "reduxLoaded"
     | "play"
     | "pause"
@@ -24,7 +23,6 @@ export type EventType =
 
 export interface EventArgs {
     platformLoaded: [];
-    esperantoLoaded: [];
     reduxLoaded: [store: Store];
     play: [state: PlayerState];
     pause: [state: PlayerState];

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -86,11 +86,12 @@ exportFunction(context, function register(service: EsperantoService): void {
 });
 
 export function resolveService<T extends EsperantoService>(id: string): Promise<T> {
-    const service = services.get(id);
-    if (service) return Promise.resolve(service as T);
-
+    const cache = services.get(id);
     const { subscriptions } = getServiceOptions(id);
-    const promise = new Promise<T>(resolve => subscriptions.add(service => resolve(service as T)));
+
+    const promise = cache
+        ? Promise.resolve(cache as T)
+        : new Promise<T>(resolve => subscriptions.add(service => resolve(service as T)));
 
     serviceIds.set(promise, id);
 

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -1,0 +1,122 @@
+import { registerContext } from "@api/context";
+import { exportFunction, registerPatch } from "@api/context/patch";
+import { createLazy } from "@shared/lazy";
+import type { ProductStateService, SettingsService, SlotsService } from "@shared/types/spotify";
+import type {
+    EsperantoMethods,
+    EsperantoService,
+    ExtractInterceptor,
+    Interceptor
+} from "@shared/types/spotify/esperanto";
+
+const services = new Map<string, EsperantoService>();
+const serviceOptions = new Map<string, ServiceOptions>();
+
+export const slotsService = resolveService<SlotsService>("spotify.ads.esperanto.proto.Slots");
+export const settingsService = resolveService<SettingsService>(
+    "spotify.ads.esperanto.proto.Settings"
+);
+export const productStateService = resolveService<ProductStateService>(
+    "spotify.product_state.esperanto.proto.ProductState"
+);
+
+interface ServiceOptions {
+    subscriptions: Set<(service: EsperantoService) => void>;
+    interceptors: Map<string, Set<Interceptor>>;
+}
+
+const { context, logger } = registerContext({
+    name: "Esperanto",
+    platforms: ["desktop", "browser"]
+});
+
+registerPatch(context, {
+    all: true,
+    find: "static SERVICE_ID",
+    replacement: {
+        match: /constructor\(\i,\i=\{\}\)\{this\.transport=\i,this\.options=\i/g,
+        replace: "$&;$exp.register(this);"
+    }
+});
+
+export function getServiceOptions(id: string): ServiceOptions {
+    let options = serviceOptions.get(id);
+    if (!options) {
+        options = { interceptors: new Map(), subscriptions: new Set() };
+        serviceOptions.set(id, options);
+    }
+
+    return options;
+}
+
+exportFunction(context, function register(service: EsperantoService): void {
+    const SERVICE_ID = service.constructor.SERVICE_ID;
+    const { interceptors, subscriptions } = getServiceOptions(SERVICE_ID);
+
+    const { onRequest, onResponse } = service.options;
+    service.options = {
+        onRequest: data => {
+            onRequest?.(data);
+            for (const { onRequest: req } of interceptors.get(data.method) ?? []) {
+                req?.(data);
+            }
+        },
+        onResponse: data => {
+            onResponse?.(data);
+            for (const { onResponse: res } of interceptors.get(data.method) ?? []) {
+                res?.(data);
+            }
+        }
+    };
+
+    // The same service can be initialized multiple times (for example to be used in the debug window).
+    // Each instance uses the same underlying transport layer, which means we only need to store it once
+    if (services.has(SERVICE_ID)) return;
+    services.set(SERVICE_ID, service);
+
+    for (const callback of subscriptions) {
+        callback(service);
+    }
+});
+
+export function resolveService<T extends EsperantoService>(id: string): Promise<T> {
+    return new Promise(resolve => {
+        const { subscriptions } = getServiceOptions(id);
+
+        subscriptions.add(service => resolve(service as T));
+    });
+}
+
+export function resolveServiceLazy<T extends EsperantoService>(id: string): T {
+    return createLazy(() => services.get(id)) as T;
+}
+
+export async function registerInterceptor<
+    T extends EsperantoService,
+    TMethod extends EsperantoMethods<T>
+>(
+    service: T | Promise<T>,
+    method: TMethod,
+    options: ExtractInterceptor<T, TMethod>
+): Promise<void> {
+    const instance = await service;
+    if (!instance) return;
+
+    const { interceptors } = getServiceOptions(instance.constructor.SERVICE_ID);
+
+    if (!(method in instance.constructor.DECODERS)) {
+        logger.error(
+            `"${method}" is not a valid method name for ${instance.constructor.SERVICE_ID}. ` +
+                `Try using a different capitalization.`
+        );
+        return;
+    }
+
+    let methodInterceptors = interceptors.get(method);
+    if (!methodInterceptors) {
+        methodInterceptors = new Set();
+        interceptors.set(method, methodInterceptors);
+    }
+
+    methodInterceptors.add(options);
+}

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -10,6 +10,7 @@ import type {
 } from "@shared/types/spotify/esperanto";
 
 const services = new Map<string, EsperantoService>();
+const serviceIds = new WeakMap<EsperantoService | Promise<EsperantoService>, string>();
 const serviceOptions = new Map<string, ServiceOptions>();
 
 export const slotsService = resolveService<SlotsService>("spotify.ads.esperanto.proto.Slots");
@@ -73,45 +74,67 @@ exportFunction(context, function register(service: EsperantoService): void {
     // Each instance uses the same underlying transport layer, which means we only need to store it once
     if (services.has(SERVICE_ID)) return;
     services.set(SERVICE_ID, service);
+    serviceIds.set(service, SERVICE_ID);
+
+    logger.debug(`Service ${SERVICE_ID} was registered.`);
 
     for (const callback of subscriptions) {
         callback(service);
     }
+
+    subscriptions.clear();
 });
 
 export function resolveService<T extends EsperantoService>(id: string): Promise<T> {
-    return new Promise(resolve => {
-        const { subscriptions } = getServiceOptions(id);
+    const service = services.get(id);
+    if (service) return Promise.resolve(service as T);
 
-        subscriptions.add(service => resolve(service as T));
-    });
+    const { subscriptions } = getServiceOptions(id);
+    const promise = new Promise<T>(resolve => subscriptions.add(service => resolve(service as T)));
+
+    serviceIds.set(promise, id);
+
+    return promise;
 }
 
 export function resolveServiceLazy<T extends EsperantoService>(id: string): T {
-    return createLazy(() => services.get(id)) as T;
+    const proxy = createLazy(resolveService<T>(id));
+    serviceIds.set(proxy, id);
+
+    return proxy;
 }
 
-export async function registerInterceptor<
+async function validateEsperantoMethod(id: string, method: string) {
+    const service = await resolveService(id).catch(() => null);
+    if (!service) {
+        logger.error(`Couldn't find service with id ${id}`);
+        return;
+    }
+
+    if (!(method in service.constructor.DECODERS)) {
+        logger.error(
+            `"${method}" is not a valid method name for ${id}. Try using a different capitalization.`
+        );
+        return;
+    }
+}
+
+export function registerInterceptor<
     T extends EsperantoService,
     TMethod extends EsperantoMethods<T>
 >(
     context: Context,
     service: T | Promise<T>,
     method: TMethod,
-    options: ExtractInterceptor<T, TMethod>
-): Promise<void> {
-    const instance = await service;
-    if (!instance) return;
+    interceptor: ExtractInterceptor<T, TMethod>
+): () => void {
+    // Using an inverse lookup map to avoid having to interact with the proxy directly
+    const SERVICE_ID = serviceIds.get(service);
+    if (!SERVICE_ID) return () => {};
 
-    const { interceptors } = getServiceOptions(instance.constructor.SERVICE_ID);
+    validateEsperantoMethod(SERVICE_ID, method);
 
-    if (!(method in instance.constructor.DECODERS)) {
-        logger.error(
-            `"${method}" is not a valid method name for ${instance.constructor.SERVICE_ID}. ` +
-                `Try using a different capitalization.`
-        );
-        return;
-    }
+    const { interceptors } = getServiceOptions(SERVICE_ID);
 
     let methodInterceptors = interceptors.get(method);
     if (!methodInterceptors) {
@@ -119,5 +142,10 @@ export async function registerInterceptor<
         interceptors.set(method, methodInterceptors);
     }
 
-    methodInterceptors.add({ enabled: () => isContextEnabled(context), interceptor: options });
+    const options = { enabled: () => isContextEnabled(context), interceptor };
+    methodInterceptors.add(options);
+
+    logger.debug(`Registered interceptor for "${method}" on ${SERVICE_ID}`);
+
+    return () => methodInterceptors.delete(options);
 }

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -58,13 +58,17 @@ exportFunction(context, function register(service: EsperantoService): void {
     service.options = {
         onRequest: data => {
             onRequest?.(data);
-            for (const { enabled, interceptor } of interceptors.get(data.method) ?? []) {
+
+            const options = interceptors.get(data.method) ?? [];
+            for (const { enabled, interceptor } of options) {
                 if (enabled()) interceptor.onRequest?.(data);
             }
         },
         onResponse: data => {
             onResponse?.(data);
-            for (const { enabled, interceptor } of interceptors.get(data.method) ?? []) {
+
+            const options = interceptors.get(data.method) ?? [];
+            for (const { enabled, interceptor } of options) {
                 if (enabled()) interceptor.onResponse?.(data);
             }
         }
@@ -72,7 +76,10 @@ exportFunction(context, function register(service: EsperantoService): void {
 
     // The same service can be initialized multiple times (for example to be used in the debug window).
     // Each instance uses the same underlying transport layer, which means we only need to store it once
-    if (services.has(SERVICE_ID)) return;
+    if (services.has(SERVICE_ID)) {
+        return;
+    }
+
     services.set(SERVICE_ID, service);
     serviceIds.set(service, SERVICE_ID);
 
@@ -87,11 +94,16 @@ exportFunction(context, function register(service: EsperantoService): void {
 
 export function resolveService<T extends EsperantoService>(id: string): Promise<T> {
     const cache = services.get(id);
-    const { subscriptions } = getServiceOptions(id);
 
-    const promise = cache
-        ? Promise.resolve(cache as T)
-        : new Promise<T>(resolve => subscriptions.add(service => resolve(service as T)));
+    let promise: Promise<T>;
+    if (cache) {
+        promise = Promise.resolve(cache as T);
+    } else {
+        const { subscriptions } = getServiceOptions(id);
+        promise = new Promise<T>(resolve => {
+            subscriptions.add(service => resolve(service as T));
+        });
+    }
 
     serviceIds.set(promise, id);
 
@@ -133,7 +145,9 @@ export function registerInterceptor<
 ): () => void {
     // Using an inverse lookup map to avoid having to interact with the proxy directly
     const SERVICE_ID = serviceIds.get(service);
-    if (!SERVICE_ID) return () => {};
+    if (!SERVICE_ID) {
+        return () => {};
+    }
 
     validateEsperantoMethod(SERVICE_ID, method);
 

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -1,4 +1,4 @@
-import { registerContext } from "@api/context";
+import { type Context, isContextEnabled, registerContext } from "@api/context";
 import { exportFunction, registerPatch } from "@api/context/patch";
 import { createLazy } from "@shared/lazy";
 import type { ProductStateService, SettingsService, SlotsService } from "@shared/types/spotify";
@@ -22,7 +22,7 @@ export const productStateService = resolveService<ProductStateService>(
 
 interface ServiceOptions {
     subscriptions: Set<(service: EsperantoService) => void>;
-    interceptors: Map<string, Set<Interceptor>>;
+    interceptors: Map<string, Set<{ interceptor: Interceptor; enabled: () => boolean }>>;
 }
 
 const { context, logger } = registerContext({
@@ -57,14 +57,14 @@ exportFunction(context, function register(service: EsperantoService): void {
     service.options = {
         onRequest: data => {
             onRequest?.(data);
-            for (const { onRequest: req } of interceptors.get(data.method) ?? []) {
-                req?.(data);
+            for (const { enabled, interceptor } of interceptors.get(data.method) ?? []) {
+                if (enabled()) interceptor.onRequest?.(data);
             }
         },
         onResponse: data => {
             onResponse?.(data);
-            for (const { onResponse: res } of interceptors.get(data.method) ?? []) {
-                res?.(data);
+            for (const { enabled, interceptor } of interceptors.get(data.method) ?? []) {
+                if (enabled()) interceptor.onResponse?.(data);
             }
         }
     };
@@ -95,6 +95,7 @@ export async function registerInterceptor<
     T extends EsperantoService,
     TMethod extends EsperantoMethods<T>
 >(
+    context: Context,
     service: T | Promise<T>,
     method: TMethod,
     options: ExtractInterceptor<T, TMethod>
@@ -118,5 +119,5 @@ export async function registerInterceptor<
         interceptors.set(method, methodInterceptors);
     }
 
-    methodInterceptors.add(options);
+    methodInterceptors.add({ enabled: () => isContextEnabled(context), interceptor: options });
 }

--- a/lib/api/esperanto.ts
+++ b/lib/api/esperanto.ts
@@ -99,7 +99,9 @@ export function resolveService<T extends EsperantoService>(id: string): Promise<
 }
 
 export function resolveServiceLazy<T extends EsperantoService>(id: string): T {
-    const proxy = createLazy(resolveService<T>(id));
+    const cache = services.get(id);
+
+    const proxy = createLazy(cache ? () => cache as T : resolveService<T>(id));
     serviceIds.set(proxy, id);
 
     return proxy;

--- a/lib/api/platform.ts
+++ b/lib/api/platform.ts
@@ -11,6 +11,9 @@ import type { PlayerAPI, PlayerState, Song } from "@shared/types/spotify/player"
 import { diffArrays } from "diff";
 
 export let platform: Platform | undefined;
+const { promise, resolve } = Promise.withResolvers<Platform>();
+export const platformPromise = promise;
+
 export const player = resolveApi<PlayerAPI>("PlayerAPI");
 export const playback = resolveApi<PlaybackAPI>("PlaybackAPI");
 export const remoteConfig = resolveApi<RemoteConfigDebugAPI>("RemoteConfigDebugAPI");
@@ -41,6 +44,7 @@ registerPatch(context, {
 
 exportFunction(context, function loadPlatform(value: Platform): Promise<Platform> {
     platform = value;
+    resolve(value);
 
     emitEvent("platformLoaded");
 

--- a/lib/api/redux.ts
+++ b/lib/api/redux.ts
@@ -11,7 +11,10 @@ const { context } = registerContext({
     platforms: ["browser", "desktop"]
 });
 
-export let globalStore: Store;
+export let globalStore: Store | undefined;
+const { promise, resolve } = Promise.withResolvers<Store>();
+export const globalStorePromise = promise;
+
 export const useSelector = findModuleExportLazy<UseSelector<any>>(
     exportFilters.byCode({
         matches: [/{equalityFn:\i/, /^(?!.*===).*/],
@@ -45,6 +48,7 @@ registerPatch(context, {
 
 exportFunction(context, function loadGlobalStore(store) {
     globalStore = store;
+    resolve(store);
 
     emitEvent("reduxLoaded", store);
 });

--- a/lib/shared/lazy.ts
+++ b/lib/shared/lazy.ts
@@ -1,20 +1,31 @@
-export function createLazy<T>(getter: () => T): T {
-    let cache: T | undefined;
+const unconfigurable = ["arguments", "caller", "prototype"];
 
-    function getTarget() {
-        if (!cache) {
-            cache = getter();
-        }
+const value = Symbol();
 
-        return cache;
+type Dummy<T> = (() => T | undefined) & { [value]?: T };
+
+const handler: ProxyHandler<Dummy<unknown>> = {
+    getOwnPropertyDescriptor: (target, p) => {
+        const obj = ((typeof p !== "string" || !unconfigurable.includes(p)) && target()) || {};
+        return Reflect.getOwnPropertyDescriptor(obj, p);
+    },
+    ownKeys: target => {
+        const keys = Reflect.ownKeys(target() || {});
+        return [...keys, ...unconfigurable.filter(key => !keys.includes(key))];
     }
+};
 
-    return new Proxy(() => {}, {
-        apply(_, thisArg, argArray) {
-            return Reflect.apply(getTarget() as any, thisArg, argArray);
-        },
-        get(_, prop, receiver) {
-            return Reflect.get(getTarget() as any, prop, receiver);
-        }
-    }) as T;
+for (const method of Reflect.ownKeys(Reflect).filter(key => typeof key === "string")) {
+    handler[method as keyof typeof handler] ??= (target, ...args: unknown[]) => {
+        return (Reflect as any)[method](target() || {}, ...args);
+    };
+}
+
+export function createLazy<T>(getter: () => T): T {
+    const dummy: Dummy<T> = () => {
+        if (!dummy[value]) dummy[value] = getter();
+        return dummy[value];
+    };
+
+    return new Proxy(dummy, handler) as T;
 }

--- a/lib/shared/lazy.ts
+++ b/lib/shared/lazy.ts
@@ -21,11 +21,16 @@ for (const method of Reflect.ownKeys(Reflect).filter(key => typeof key === "stri
     };
 }
 
-export function createLazy<T>(getter: () => T): T {
+export function createLazy<T>(getter: (() => T) | PromiseLike<T>): T {
     const dummy: Dummy<T> = () => {
-        if (!dummy[value]) dummy[value] = getter();
+        if (typeof getter === "function") dummy[value] ??= getter();
         return dummy[value];
     };
+
+    if ("then" in getter)
+        getter.then(resolved => {
+            dummy[value] = resolved;
+        });
 
     return new Proxy(dummy, handler) as T;
 }

--- a/lib/shared/types/spotify/ads.d.ts
+++ b/lib/shared/types/spotify/ads.d.ts
@@ -68,19 +68,3 @@ export interface Ad {
     trackingEvents: any;
     video: any[];
 }
-
-export interface AdsTestingClient {
-    addPlaytime(opts: { seconds: number });
-}
-
-export interface SlotsClient {
-    clearAllAds(params: { slotId: string }): Promise<void>;
-    getSlots(): Promise<{ adSlots: { slotId: string; slot_id: string }[] }>;
-}
-
-export interface SlotSettingsClient {
-    updateAdServerEndpoint(params: { slotIds: string[]; url: string }): Promise<void>;
-    updateDisplayTimeInterval(params: { slotId: string; timeInterval: bigint }): Promise<void>;
-    updateSlotEnabled(params: { slotId: string; enabled: boolean }): Promise<void>;
-    updateStreamTimeInterval(params: { slotId: string; timeInterval: bigint }): Promise<void>;
-}

--- a/lib/shared/types/spotify/esperanto.d.ts
+++ b/lib/shared/types/spotify/esperanto.d.ts
@@ -1,0 +1,93 @@
+type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
+
+// Contravariance hack, makes type extraction less annoying
+declare const __key: unique symbol;
+
+interface ProtoCodec<T> {
+    fromPartial(object: DeepPartial<T>): T;
+    encode(message: T): { finish(): Uint8Array };
+    decode(reader: unknown, length?: number): T;
+}
+
+interface Payload<T, TMethod extends string = string, TStream extends boolean = boolean> {
+    type: TStream extends false ? "single" : "stream";
+    service: string;
+    method: TMethod;
+    message: T;
+    messageType: ProtoCodec<T>;
+}
+
+type Method<TRequest, TResponse> = (
+    request?: DeepPartial<TRequest>,
+    options?: { signal?: AbortSignal }
+) => Promise<TResponse>;
+
+type StreamMethod<TRequest, TResponse> = (
+    request: DeepPartial<TRequest>,
+    onData: (response: TResponse) => void
+) => { cancel: () => void };
+
+type CallableProps<T extends object> = {
+    [K in Extract<keyof T, string>]: T[K] extends (...args: any[]) => unknown ? K : never;
+}[Extract<keyof T, string>];
+
+// For some reason spotify is super inconsistent when it comes to capitalization
+type EsperantoMethodName<T extends string = string> = Capitalize<T> | Uncapitalize<T>;
+export type EsperantoMethods<T extends object> = EsperantoMethodName<CallableProps<T>>;
+
+export interface Interceptor<
+    TReq = unknown,
+    TRes = unknown,
+    TMethod extends string = string & {},
+    TStream extends boolean = boolean
+> {
+    onRequest?(payload: Payload<TReq, TMethod, TStream>): void;
+    onResponse?(payload: Payload<TRes, TMethod, TStream>): void;
+}
+
+export type ExtractInterceptor<
+    T extends EsperantoService,
+    TMethod extends EsperantoMethods<T>
+> = Omit<Extract<T["options"], { [__key]: EsperantoMethodName<TMethod> }>, typeof __key>;
+
+type MethodInterceptor<
+    T extends Record<string, unknown> = Record<string, unknown>,
+    TMethod extends CallableProps<T> = CallableProps<T>
+> = InferMethodTypes<T[TMethod]> extends [infer Req, infer Res, infer Stream extends boolean]
+    ? Interceptor<Req, Res, TMethod, Stream> & { [__key]: EsperantoMethodName<TMethod> }
+    : never;
+
+type InferMethodTypes<T> = T extends (req: infer Request) => infer Response
+    ? [Request, Response, false]
+    : T extends (req: infer Request, cb: (res?: infer Response) => unknown) => unknown
+      ? [Request, Response, true]
+      : [];
+
+export type EsperantoService<T extends Record<string, unknown> = Record<string, unknown>> = {
+    constructor: EsperantoServiceClass<T>;
+    options: { [K in CallableProps<T>]: MethodInterceptor<T, K> }[CallableProps<T>] | Interceptor;
+} & {
+    [K in keyof T]: InferMethodTypes<T[K]> extends [infer Req, infer Res, infer Stream]
+        ? Stream extends false
+            ? Method<Req, Res>
+            : StreamMethod<Req, Res>
+        : T[K];
+};
+
+interface EsperantoServiceClass<T extends Record<string, unknown> = Record<string, unknown>> {
+    SERVICE_ID: string;
+    METHODS: {
+        [K in CallableProps<T>]: InferMethodTypes<T[K]> extends [infer Req, infer Res, infer Stream]
+            ? { isStreaming: Stream; requestType: ProtoCodec<Req>; responseType: ProtoCodec<Res> }
+            : never;
+    };
+    DECODERS: {
+        [K in CallableProps<T> as EsperantoMethodName<K>]: InferMethodTypes<T[K]> extends [
+            infer Req,
+            infer Res,
+            boolean
+        ]
+            ? { request: ProtoCodec<Req>["decode"]; response: ProtoCodec<Res>["decode"] }
+            : never;
+    };
+}

--- a/lib/shared/types/spotify/index.d.ts
+++ b/lib/shared/types/spotify/index.d.ts
@@ -1,11 +1,10 @@
 import type { AdManagers } from "@shared/types/spotify/ads";
 import type { EsperantoService } from "@shared/types/spotify/esperanto";
 import type { AnyExperiment } from "@shared/types/spotify/experiments";
+import type { SettingsAPI } from "@shared/types/spotify/settings";
 import type { User } from "@shared/types/spotify/user";
 
 import type { History } from "history";
-
-import type { SettingsAPI } from "./settings";
 
 export interface Platform {
     container: "Desktop";

--- a/lib/shared/types/spotify/index.d.ts
+++ b/lib/shared/types/spotify/index.d.ts
@@ -1,8 +1,11 @@
-import type { AdManagers, SettingsAPI } from "@shared/types/spotify/ads";
+import type { AdManagers } from "@shared/types/spotify/ads";
 import type { AnyExperiment } from "@shared/types/spotify/experiments";
 import type { User } from "@shared/types/spotify/user";
 
 import type { History } from "history";
+
+import type { EsperantoService } from "./esperanto";
+import type { SettingsAPI } from "./settings";
 
 export interface Platform {
     container: "Desktop";
@@ -214,4 +217,27 @@ export interface SpotifyURI {
     clone(): SpotifyURI;
 }
 
-export type Capabilities = Record<boolean | (() => boolean)>;
+export type Capabilities = Record<string, boolean | (() => boolean)>;
+
+export type SlotsService = EsperantoService<{
+    getSlots: () => { adSlots: { slotId: string }[] };
+    clearAllAds: (request: { slotId: string }) => void;
+    subSlot: (request: { slotId: string }, cb: () => void) => void;
+}>;
+
+export type SettingsService = EsperantoService<{
+    updateAdServerEndpoint: (request: { slotIds: string[]; url: string }) => void;
+    updateSlotEnabled: (request: { slotId: string; enabled: boolean }) => void;
+    updateDisplayTimeInterval: (request: { slotId: string; timeInterval: bigint }) => void;
+    updateStreamTimeInterval: (request: { slotId: string; timeInterval: bigint }) => void;
+    updateExpiryTimeInterval: (request: { slotId: string; timeInterval: bigint }) => void;
+}>;
+
+export interface ProductStateRaw {
+    pairs: Record<string, string>;
+}
+
+export type ProductStateService = EsperantoService<{
+    getValues: () => ProductStateRaw;
+    subValues: (request: null, cb: (response: ProductStateRaw) => void) => void;
+}>;

--- a/lib/shared/types/spotify/index.d.ts
+++ b/lib/shared/types/spotify/index.d.ts
@@ -1,10 +1,10 @@
 import type { AdManagers } from "@shared/types/spotify/ads";
+import type { EsperantoService } from "@shared/types/spotify/esperanto";
 import type { AnyExperiment } from "@shared/types/spotify/experiments";
 import type { User } from "@shared/types/spotify/user";
 
 import type { History } from "history";
 
-import type { EsperantoService } from "./esperanto";
 import type { SettingsAPI } from "./settings";
 
 export interface Platform {

--- a/lib/shared/types/spotify/index.d.ts
+++ b/lib/shared/types/spotify/index.d.ts
@@ -181,6 +181,7 @@ export interface ProductStateAPI {
         putOverridesValues(values: any): void;
         subValues(opts: { keys: string[] }, callback: () => void);
     };
+    cache: { clear: () => void };
 }
 
 export interface CosmosAPI {

--- a/src/plugins/adBlock.ts
+++ b/src/plugins/adBlock.ts
@@ -1,139 +1,91 @@
-import { registerInterval } from "@api/context";
-import { exportFunction, registerPatch } from "@api/context/patch";
+import { registerEventListener } from "@api/context/event";
 import { registerPlugin } from "@api/context/plugin";
-import { platform, productState, registerApiOverride } from "@api/platform";
-import { globalStore } from "@api/redux";
-import type { ProductStateAPI } from "@shared/types/spotify";
-import type { SlotSettingsClient, SlotsClient } from "@shared/types/spotify/ads";
-import { exportFilters, findModuleExportLazy } from "@webpack/module";
+import { isPluginEnabled } from "@api/context/settings";
+import {
+    productStateService,
+    registerInterceptor,
+    settingsService,
+    slotsService
+} from "@api/esperanto";
+import { platform } from "@api/platform";
+import type {
+    Platform,
+    ProductStateRaw,
+    SettingsService,
+    SlotsService
+} from "@shared/types/spotify";
 
-const slotsClient = findModuleExportLazy<SlotsClient>(
-    exportFilters.byProps("clearAllAds", "getSlots")
-);
-const settingsClient = findModuleExportLazy<SlotSettingsClient>(
-    exportFilters.byProps("updateAdServerEndpoint")
-);
+import type { Store } from "redux";
 
-const { plugin, logger } = registerPlugin({
-    authors: ["7elia"],
+const MAX_UINT64 = 2n ** 64n - 1n;
+
+const platformPromise = Promise.withResolvers<Platform>();
+const reduxPromise = Promise.withResolvers<Store>();
+const callbacks: { cancel: () => void }[] = [];
+
+const { plugin } = registerPlugin({
+    authors: ["7elia", "davri"],
     description: "Block ads on Spotify",
     name: "AdBlock",
-    platforms: ["desktop", "browser"]
-});
-
-registerInterval(plugin, configure, 10_000);
-registerInterval(plugin, configureReduxState, 1000);
-
-registerPatch(plugin, {
-    find: 'type:"PLAY_AT_FIRST_TAP_HAD_DEFERRED_ACTIONS"',
-    replacement: {
-        match: /(\.\.\.\i,productState:)(\i\.data)/,
-        replace: "$1$exp.modifyProductStateRaw($2)"
+    platforms: ["desktop", "browser"],
+    async start() {
+        await platformPromise.promise.then(configureAdManagers);
+        await reduxPromise.promise.then(configureReduxState);
+        await Promise.all([slotsService, settingsService])
+            .then(args => configureServices(...args))
+            .then(cbs => callbacks.push(...cbs));
+    },
+    stop() {
+        // remove existing callbacks to prevent memory leaks
+        callbacks.forEach(cb => void cb.cancel());
+        callbacks.length = 0;
     }
 });
 
-registerPatch(plugin, {
-    find: '"xpui"',
-    replacement: {
-        match: /(initialProductState:)(\i),/,
-        replace: "$1$exp.modifyProductStateRaw($2),"
-    }
+registerEventListener(plugin, "platformLoaded", () =>
+    platformPromise.resolve(platform as Platform)
+);
+registerEventListener(plugin, "reduxLoaded", store => reduxPromise.resolve(store));
+
+registerInterceptor(productStateService, "GetValues", {
+    onResponse: ({ message }) => modifyProductStateRaw(message)
+});
+registerInterceptor(productStateService, "SubValues", {
+    onResponse: ({ message }) => modifyProductStateRaw(message)
 });
 
-function modifyProductStateRaw(values: any) {
-    return {
-        ...values,
+function modifyProductStateRaw(data: ProductStateRaw) {
+    if (!isPluginEnabled(plugin)) return;
+    Object.assign(data.pairs, {
         ads: "0",
         catalogue: "premium",
         type: "premium"
-    };
+    });
 }
 
-exportFunction(plugin, modifyProductStateRaw);
-
-registerApiOverride(plugin, "ProductStateAPI", async function getValues(this: ProductStateAPI) {
-    const values = await (this as any).getValues_orig();
-    return modifyProductStateRaw(values);
-});
-
-registerApiOverride(
-    plugin,
-    "ProductStateAPI",
-    async function getCachedValues(this: ProductStateAPI) {
-        const values = await (this as any).getCachedValues_orig();
-        return modifyProductStateRaw(values);
-    }
-);
-
-async function configure() {
-    try {
-        await configureSlotsClient();
-    } catch {
-        logger.warn("Blocking slotted ads might be patched");
-    }
-    await configureAdManagers();
-    configureProductState();
-}
-
-/** I'm pretty sure this is patched */
-async function configureSlotsClient() {
-    if (!platform || !slotsClient) {
-        return;
-    }
-
-    const { audio } = platform.getAdManagers();
-
-    const slots = await slotsClient.getSlots();
-    for (const slot of slots.adSlots) {
-        const slotId = slot.slotId ?? slot.slot_id;
-        if (!slotId) {
-            continue;
-        }
-
+async function configureServices(slotsService: SlotsService, settingsService: SettingsService) {
+    const slots = await slotsService.getSlots();
+    return slots.adSlots.map(({ slotId }) => {
         async function clearSlot() {
-            slotsClient.clearAllAds({ slotId });
+            await slotsService.clearAllAds({ slotId });
 
-            await settingsClient.updateAdServerEndpoint({
+            await settingsService.updateAdServerEndpoint({
                 slotIds: [slotId],
                 url: "https://poop.com"
             });
-            await settingsClient.updateSlotEnabled({ enabled: false, slotId });
-            await settingsClient.updateStreamTimeInterval({ slotId, timeInterval: BigInt(0) });
-            await settingsClient.updateDisplayTimeInterval({ slotId, timeInterval: BigInt(0) });
+            await settingsService.updateSlotEnabled({ enabled: false, slotId });
+            await settingsService.updateStreamTimeInterval({ slotId, timeInterval: MAX_UINT64 });
+            await settingsService.updateDisplayTimeInterval({ slotId, timeInterval: MAX_UINT64 });
+            await settingsService.updateExpiryTimeInterval({ slotId, timeInterval: MAX_UINT64 });
         }
 
-        await clearSlot();
+        clearSlot();
 
-        audio.inStreamApi.adsCoreConnector.subscribeToSlot(slotId, async () => {
-            audio.inStreamApi.adsCoreConnector.clearSlot(slotId);
-
-            await clearSlot();
-        });
-    }
-}
-
-// TODO: (await resolveApi("ProductStateAPI").productStateApi.getValues()).pairs["financial-product"]
-function configureProductState() {
-    const overrides = {
-        pairs: {
-            ads: "0",
-            catalogue: "premium",
-            type: "premium"
-        }
-    };
-
-    productState.productStateApi.subValues({ keys: ["ads", "catalogue", "type"] }, () => {
-        productState.productStateApi.putOverridesValues(overrides);
+        return slotsService.subSlot({ slotId }, clearSlot);
     });
-
-    productState.productStateApi.putOverridesValues(overrides);
 }
 
-async function configureAdManagers() {
-    if (!platform) {
-        return;
-    }
-
+async function configureAdManagers(platform: Platform) {
     const { audio, billboard, inStreamApi, leaderboard, sponsoredPlaylist, vto } =
         platform.getAdManagers();
 
@@ -145,11 +97,7 @@ async function configureAdManagers() {
     vto.manager.disable();
 }
 
-function configureReduxState() {
-    if (!globalStore) {
-        return;
-    }
-
+function configureReduxState(globalStore: Store) {
     const { root } = globalStore.getState().ads;
     if (!root.adsEnabled && root.isHptoHidden && root.isPremium) {
         return;

--- a/src/plugins/adBlock.ts
+++ b/src/plugins/adBlock.ts
@@ -1,13 +1,12 @@
-import { registerEventListener } from "@api/context/event";
 import { registerPlugin } from "@api/context/plugin";
-import { isPluginEnabled } from "@api/context/settings";
 import {
     productStateService,
     registerInterceptor,
     settingsService,
     slotsService
 } from "@api/esperanto";
-import { platform } from "@api/platform";
+import { platformPromise } from "@api/platform";
+import { globalStorePromise } from "@api/redux";
 import type {
     Platform,
     ProductStateRaw,
@@ -19,8 +18,6 @@ import type { Store } from "redux";
 
 const MAX_UINT64 = 2n ** 64n - 1n;
 
-const platformPromise = Promise.withResolvers<Platform>();
-const reduxPromise = Promise.withResolvers<Store>();
 const callbacks: { cancel: () => void }[] = [];
 
 const { plugin } = registerPlugin({
@@ -29,8 +26,8 @@ const { plugin } = registerPlugin({
     name: "AdBlock",
     platforms: ["desktop", "browser"],
     async start() {
-        await platformPromise.promise.then(configureAdManagers);
-        await reduxPromise.promise.then(configureReduxState);
+        await platformPromise.then(configureAdManagers);
+        await globalStorePromise.then(configureReduxState);
         await Promise.all([slotsService, settingsService])
             .then(args => configureServices(...args))
             .then(cbs => callbacks.push(...cbs));
@@ -42,20 +39,14 @@ const { plugin } = registerPlugin({
     }
 });
 
-registerEventListener(plugin, "platformLoaded", () =>
-    platformPromise.resolve(platform as Platform)
-);
-registerEventListener(plugin, "reduxLoaded", store => reduxPromise.resolve(store));
-
-registerInterceptor(productStateService, "GetValues", {
+registerInterceptor(plugin, productStateService, "GetValues", {
     onResponse: ({ message }) => modifyProductStateRaw(message)
 });
-registerInterceptor(productStateService, "SubValues", {
+registerInterceptor(plugin, productStateService, "SubValues", {
     onResponse: ({ message }) => modifyProductStateRaw(message)
 });
 
 function modifyProductStateRaw(data: ProductStateRaw) {
-    if (!isPluginEnabled(plugin)) return;
     Object.assign(data.pairs, {
         ads: "0",
         catalogue: "premium",

--- a/src/plugins/adBlock.ts
+++ b/src/plugins/adBlock.ts
@@ -20,7 +20,7 @@ const MAX_UINT64 = 2n ** 64n - 1n;
 
 const callbacks: { cancel: () => void }[] = [];
 
-const { plugin } = registerPlugin({
+const { plugin, logger } = registerPlugin({
     authors: ["7elia", "Davr1"],
     description: "Block ads on Spotify",
     name: "AdBlock",
@@ -74,6 +74,8 @@ async function configureServices(slotsService: SlotsService, settingsService: Se
 
         clearSlot();
 
+        logger.debug(`Configured slot ${slotId}.`);
+
         return slotsService.subSlot({ slotId }, clearSlot);
     });
 }
@@ -88,6 +90,8 @@ async function configureAdManagers(platform: Platform) {
     leaderboard.disableLeaderboard();
     sponsoredPlaylist.disable();
     vto.manager.disable();
+
+    logger.debug(`Configured ad managers.`);
 }
 
 function configureReduxState(globalStore: Store) {
@@ -100,4 +104,6 @@ function configureReduxState(globalStore: Store) {
     globalStore.dispatch({ isPremium: true, type: "ADS_PREMIUM" });
     globalStore.dispatch({ isHptoHidden: true, type: "ADS_HPTO_HIDDEN" });
     globalStore.dispatch({ type: "ADS_POST_HIDE_HPTO" });
+
+    logger.debug(`Configured redux state.`);
 }

--- a/src/plugins/adBlock.ts
+++ b/src/plugins/adBlock.ts
@@ -5,7 +5,7 @@ import {
     settingsService,
     slotsService
 } from "@api/esperanto";
-import { platformPromise } from "@api/platform";
+import { platformPromise, productState } from "@api/platform";
 import { globalStorePromise } from "@api/redux";
 import type {
     Platform,
@@ -26,6 +26,8 @@ const { plugin } = registerPlugin({
     name: "AdBlock",
     platforms: ["desktop", "browser"],
     async start() {
+        if ("cache" in productState) productState.cache.clear();
+
         await platformPromise.then(configureAdManagers);
         await globalStorePromise.then(configureReduxState);
         await Promise.all([slotsService, settingsService])

--- a/src/plugins/adBlock.ts
+++ b/src/plugins/adBlock.ts
@@ -21,7 +21,7 @@ const MAX_UINT64 = 2n ** 64n - 1n;
 const callbacks: { cancel: () => void }[] = [];
 
 const { plugin } = registerPlugin({
-    authors: ["7elia", "davri"],
+    authors: ["7elia", "Davr1"],
     description: "Block ads on Spotify",
     name: "AdBlock",
     platforms: ["desktop", "browser"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["DOM", "ESNext", "ESNext.Iterator"],
-        "target": "es6",
+        "target": "es2020",
         "module": "preserve",
         "moduleDetection": "force",
         "jsx": "preserve",


### PR DESCRIPTION
This PR adds support for the Spotify Esperanto layer, which makes it possible to intercept messages at the earliest point possible. This removes the need for patching the ProductState object in different parts of the code, or repeatedly running the injection logic in a set interval, which was prone to failing.

I've also rewritten the lazy proxy since it was hard to debug (e.g. {...proxy} would return an empty object) and could throw an error when Reflect methods were used on `undefined`.